### PR TITLE
fix: Search results not displaying

### DIFF
--- a/app/ChatClientPage.tsx
+++ b/app/ChatClientPage.tsx
@@ -149,7 +149,21 @@ export default function ChatClientPage() {
 
           {/* Search Results */}
           {searchResults.length > 0 && (
-            <SearchResultsAccordion results={searchResults} />
+            <SearchResultsAccordion 
+              searchResults={searchResults.reduce((acc: any, result: any) => {
+                const shortId = result.chunk_id?.substring(0, 7) || result.id?.substring(0, 7);
+                acc[shortId] = {
+                  id: result.chunk_id || result.id,
+                  documentId: result.document_id,
+                  ownerId: '',
+                  collectionIds: [],
+                  score: result.score,
+                  text: result.text,
+                  metadata: result.metadata
+                };
+                return acc;
+              }, {})} 
+            />
           )}
 
           {/* Messages */}


### PR DESCRIPTION
Fixes #5

## Summary
Fixed the issue where search results were not displaying in the chat interface.

## Changes
- Corrected the prop name from `results` to `searchResults` in SearchResultsAccordion component
- Transformed the searchResults array into the expected object format
- Each search result is now properly mapped with a short ID as the key

Generated with [Claude Code](https://claude.ai/code)